### PR TITLE
RXR-47 fix issue with test not working when "delta" is missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: json2test
 Type: Package
 Title: Run R package tests specified in JSON
-Version: 0.1.10
+Version: 0.1.11
 Author: Ron Keizer
 Maintainer: Ron Keizer <ronkeizer@gmail.com>
 Description: R library to allow tests and reference values to be

--- a/R/json_test.R
+++ b/R/json_test.R
@@ -167,7 +167,7 @@ json_test <- function(
             } else {
               equal_i <- TRUE
               ref_i <- ref
-              if(class(ref) == "list" && !is.null(ref$value) && !is.null(ref$delta)) {
+              if(class(ref) == "list" && !is.null(ref$value)) {
                 ref_i <- ref$value
                 if(!is.null(ref$delta)) {
                   equal_i <- FALSE


### PR DESCRIPTION
This fixes an issue with json2test where it wouldn't execute the test if the reference was defined as:

```
{ "value": "...." }
```
so without the "delta" element that we generally add. For `character` type comparisons we don't add `delta` of course, so that's why these were not executed. 

Ticket: https://insight-rx.atlassian.net/browse/RXR-47?atlOrigin=eyJpIjoiZjg0NTE5Mjg5MzJlNDViOGE2NWRhZDE5Y2E1NDQ3YmEiLCJwIjoiaiJ9